### PR TITLE
Fix for scanning via file/share not finding QR codes

### DIFF
--- a/app/src/main/java/de/t_dankworth/secscanqr/activities/ScannerActivity.java
+++ b/app/src/main/java/de/t_dankworth/secscanqr/activities/ScannerActivity.java
@@ -356,7 +356,6 @@ public class ScannerActivity extends AppCompatActivity {
         try{
             Hashtable<DecodeHintType, Object> decodeHints = new Hashtable<DecodeHintType, Object>();
             decodeHints.put(DecodeHintType.TRY_HARDER, Boolean.TRUE);
-            decodeHints.put(DecodeHintType.PURE_BARCODE, Boolean.TRUE);
 
             Result result = reader.decode(bitmap, decodeHints);
             qrcodeFormat =result.getBarcodeFormat().toString();


### PR DESCRIPTION
This commit simply removes DecodeHintType.PURE_BARCODE as it unnecessarily restricts detection to "monochrome image of a barcode". Example image which failed for me before and now works perfectly: https://www.qr-code-generator.com/wp-content/themes/qr/img-v4/qr-codes-on/gallery/books/06-facebook-beagle-publishing-books@3x.png